### PR TITLE
Create an ugly html search view

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -11,9 +11,14 @@ module Api
         locations = Location.search(params).page(params[:page]).
                     per(params[:per_page])
 
-        if stale?(etag: cache_key(locations), public: true)
-          generate_pagination_headers(locations)
-          render json: locations.preload(tables), each_serializer: LocationsSerializer, status: 200
+        respond_to do |format|
+          format.json do
+            if stale?(etag: cache_key(locations), public: true)
+              generate_pagination_headers(locations)
+              render json: locations.preload(tables), each_serializer: LocationsSerializer, status: 200
+            end
+          end
+          format.html { render locals: { locations: locations.preload(tables) } }
         end
       end
 

--- a/app/views/api/v1/search/index.html.haml
+++ b/app/views/api/v1/search/index.html.haml
@@ -1,5 +1,8 @@
 %h3 Location Search
 
+.btn-group
+  = link_to 'JSON', params.merge(format: 'json'), {class: 'btn btn-default'}
+
 %table
   %thead
     %tr

--- a/app/views/api/v1/search/index.html.haml
+++ b/app/views/api/v1/search/index.html.haml
@@ -1,0 +1,22 @@
+%h3 Location Search
+
+%table
+  %thead
+    %tr
+      %th name
+      %th organization
+      %th address
+      %th phones
+      %th literally everything else
+  %tbody
+    - locations.each do |l|
+      %tr
+        %th= l.name
+        %td
+          %pre= l.organization.pretty_inspect
+        %td
+          %pre= l.address.pretty_inspect
+        %td
+          %pre= l.phones.pretty_inspect
+        %td
+          %pre= l.pretty_inspect


### PR DESCRIPTION
This search view now has an html view instead of just JSON

Your app server address will vary FYI :)

To use: http://ohana-api.dev/api/search.html?keyword=food

To see: 
![ohana_api](https://cloud.githubusercontent.com/assets/4354/6314863/48532d8e-b9bd-11e4-88bc-48602a4b7787.png)

Anywho, somebody with front-end taste is welcome to fix this up, and I'll be setting up more controller endpoints to work with HTML.
