### PR TITLE
Document phantomjs dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,6 +65,12 @@ your needs.
 
 _Note: Installation and preparation can take several minutes to complete!_
 
+### Install phantomjs
+
+On OS X, you can install phantomjs using Homebrew:
+
+    brew install phantomjs
+
 ### Run the app
 
 Start the app locally on port 8080:


### PR DESCRIPTION
My tests were failing since the phantomjs executable was missing, so I'm documenting the dependency here with instructions for OS X.
